### PR TITLE
Implement Discovery Section

### DIFF
--- a/src/components/FormContent/FormContent.jsx
+++ b/src/components/FormContent/FormContent.jsx
@@ -7,6 +7,7 @@ import InterviewerSection from 'components/sections/InterviewerSection';
 import BasicInformationSection from 'components/sections/BasicInformationSection';
 import DemographicsSection from 'components/sections/DemographicsSection';
 import PatientCareSection from 'components/sections/PatientCareSection';
+import DiscoverySection from 'components/sections/DiscoverySection';
 import HistorySection from 'components/sections/HistorySection';
 import SymptomsSection from 'components/sections/SymptomsSection';
 
@@ -20,7 +21,7 @@ const sections = [
   { id: 'demographics', title: 'demographics', section: <DemographicsSection /> },
   { id: 'patientCare', title: 'patient care', section: <PatientCareSection /> },
   { id: 'exposure', title: 'exposure' },
-  { id: 'discovery', title: 'discovery' },
+  { id: 'discovery', title: 'discovery', section: <DiscoverySection /> },
   { id: 'symptoms', title: 'symptoms', section: <SymptomsSection /> },
   { id: 'history', title: 'history', section: <HistorySection /> },
   { id: 'testing', title: 'testing' },

--- a/src/components/FormContent/FormContent.jsx
+++ b/src/components/FormContent/FormContent.jsx
@@ -8,8 +8,8 @@ import BasicInformationSection from 'components/sections/BasicInformationSection
 import DemographicsSection from 'components/sections/DemographicsSection';
 import PatientCareSection from 'components/sections/PatientCareSection';
 import DiscoverySection from 'components/sections/DiscoverySection';
-import HistorySection from 'components/sections/HistorySection';
 import SymptomsSection from 'components/sections/SymptomsSection';
+import HistorySection from 'components/sections/HistorySection';
 
 import useTOC from 'hooks/useTOC';
 import useStyles from './styles';

--- a/src/components/FormProvider/initialValues.js
+++ b/src/components/FormProvider/initialValues.js
@@ -50,6 +50,10 @@ const initialValues = {
   death: '',
   deathDate: null,
   deathDateUnknown: '',
+  // discovery
+  discoveryProcess: '',
+  dgmqid: '',
+  otherDiscoveryProcess: '',
   // history
   pregnant: '',
   currentSmoker: '',

--- a/src/components/sections/DiscoverySection/DiscoverySection.js
+++ b/src/components/sections/DiscoverySection/DiscoverySection.js
@@ -1,10 +1,9 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { unstable_batchedUpdates as batch } from 'react-dom';
 import Grid from '@material-ui/core/Grid';
 import { useFormikContext } from 'formik';
 
-import SelectBox from 'components/forms/SelectBox';
-import TextField from 'components/forms/TextField';
+import { SelectBox, TextField } from 'components/forms';
 import useStyles from './styles';
 
 const discoveryProcessOptions = [
@@ -18,35 +17,26 @@ const discoveryProcessOptions = [
 
 function DiscoverySection() {
   const styles = useStyles();
-  const { values, setFieldValue } = useFormikContext();
-
-  const handleDiscoveryProcessChange = useCallback(
-    e => {
-      const option = e.target.value;
-      batch(() => {
-        setFieldValue('discoveryProcess', option);
-        if (option !== 'epiXNotification') {
-          setFieldValue('dgmqid', '');
-        }
-        if (option !== 'other') {
-          setFieldValue('otherDiscoveryProcess', '');
-        }
-      });
-    },
-    [setFieldValue]
-  );
+  const { values, setFieldValue, handleChange } = useFormikContext();
 
   return (
     <Grid container spacing={3}>
       <Grid item xs={12} className={styles['simple-text']}>
         Under what process was the PUI or case first <strong>identified</strong>?
       </Grid>
+
       <Grid item xs={9}>
         <SelectBox
           name="discoveryProcess"
           label="Discovery Process"
           options={discoveryProcessOptions}
-          onChange={handleDiscoveryProcessChange}
+          onChange={e => {
+            batch(() => {
+              handleChange(e);
+              setFieldValue('dgmqid', '');
+              setFieldValue('otherDiscoveryProcess', '');
+            });
+          }}
         />
       </Grid>
 

--- a/src/components/sections/DiscoverySection/DiscoverySection.js
+++ b/src/components/sections/DiscoverySection/DiscoverySection.js
@@ -1,0 +1,72 @@
+import React, { useCallback } from 'react';
+import { unstable_batchedUpdates as batch } from 'react-dom';
+import Grid from '@material-ui/core/Grid';
+import { useFormikContext } from 'formik';
+
+import SelectBox from 'components/forms/SelectBox';
+import TextField from 'components/forms/TextField';
+import useStyles from './styles';
+
+const discoveryProcessOptions = [
+  { value: 'clinicalEvaluation', label: 'Clinical evaluation leading to PUI determination' },
+  { value: 'contactTracing', label: 'Contact tracing of case patient' },
+  { value: 'routineSurveillance', label: 'Routine surveillance' },
+  { value: 'epiXNotification', label: 'EpiX notification of travelers' },
+  { value: 'unknown', label: 'Unknown' },
+  { value: 'other', label: 'Other' }
+];
+
+function DiscoverySection() {
+  const styles = useStyles();
+  const { values, setFieldValue } = useFormikContext();
+
+  const handleDiscoveryProcessChange = useCallback(
+    e => {
+      const option = e.target.value;
+      batch(() => {
+        setFieldValue('discoveryProcess', option);
+        if (option !== 'epiXNotification') {
+          setFieldValue('dgmqid', '');
+        }
+        if (option !== 'other') {
+          setFieldValue('otherDiscoveryProcess', '');
+        }
+      });
+    },
+    [setFieldValue]
+  );
+
+  return (
+    <Grid container spacing={3}>
+      <Grid item xs={12} className={styles['simple-text']}>
+        Under what process was the PUI or case first <strong>identified</strong>?
+      </Grid>
+      <Grid item xs={9}>
+        <SelectBox
+          name="discoveryProcess"
+          label="Discovery Process"
+          options={discoveryProcessOptions}
+          onChange={handleDiscoveryProcessChange}
+        />
+      </Grid>
+
+      {values.discoveryProcess === 'epiXNotification' && (
+        <Grid item xs={6}>
+          <TextField name="dgmqid" label="DGMQID" autoComplete="off" />
+        </Grid>
+      )}
+
+      {values.discoveryProcess === 'other' && (
+        <Grid item xs={6}>
+          <TextField
+            name="otherDiscoveryProcess"
+            label="Other Discovery Process"
+            autoComplete="off"
+          />
+        </Grid>
+      )}
+    </Grid>
+  );
+}
+
+export default DiscoverySection;

--- a/src/components/sections/DiscoverySection/index.js
+++ b/src/components/sections/DiscoverySection/index.js
@@ -1,0 +1,1 @@
+export { default } from './DiscoverySection';

--- a/src/components/sections/DiscoverySection/styles.js
+++ b/src/components/sections/DiscoverySection/styles.js
@@ -1,0 +1,11 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export default makeStyles(
+  theme => ({
+    'simple-text': {
+      fontFamily: theme.typography.primary.fontFamily,
+      color: theme.palette.text.primary
+    }
+  }),
+  { name: 'DiscoverySection' }
+);


### PR DESCRIPTION
This implements the Discovery Section.

Note the approach to clearing the `other` and `dgmqid` fields when the `Discovery Process` select box is changed.  If this approach seems valid, it should be implemented elsewhere as well.