### PR TITLE
Implement Exposure Section

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@date-io/date-fns": "^1.3.13",
+    "@fortawesome/fontawesome-svg-core": "^1.2.27",
+    "@fortawesome/free-solid-svg-icons": "^5.12.1",
+    "@fortawesome/react-fontawesome": "^0.1.9",
     "@material-ui/core": "^4.9.7",
     "@material-ui/lab": "^4.0.0-alpha.46",
     "@material-ui/pickers": "^3.2.10",

--- a/src/components/FormContent/FormContent.jsx
+++ b/src/components/FormContent/FormContent.jsx
@@ -10,6 +10,7 @@ import PatientCareSection from 'components/sections/PatientCareSection';
 import DiscoverySection from 'components/sections/DiscoverySection';
 import SymptomsSection from 'components/sections/SymptomsSection';
 import HistorySection from 'components/sections/HistorySection';
+import ExposureSection from 'components/sections/ExposureSection';
 
 import useTOC from 'hooks/useTOC';
 import useStyles from './styles';

--- a/src/components/FormContent/FormContent.jsx
+++ b/src/components/FormContent/FormContent.jsx
@@ -21,7 +21,7 @@ const sections = [
   { id: 'basicInformation', title: 'basic information', section: <BasicInformationSection /> },
   { id: 'demographics', title: 'demographics', section: <DemographicsSection /> },
   { id: 'patientCare', title: 'patient care', section: <PatientCareSection /> },
-  { id: 'exposure', title: 'exposure' },
+  { id: 'exposure', title: 'exposure', section: <ExposureSection /> },
   { id: 'discovery', title: 'discovery', section: <DiscoverySection /> },
   { id: 'symptoms', title: 'symptoms', section: <SymptomsSection /> },
   { id: 'history', title: 'history', section: <HistorySection /> },

--- a/src/components/FormProvider/initialValues.js
+++ b/src/components/FormProvider/initialValues.js
@@ -19,6 +19,7 @@ const exposureInitialValues = {
 
 // DateField names need to be null, all other can be ''
 const initialValues = {
+  // identifiers
   knownContact: '',
   contactId: '',
   reportingJurisdiction: '',

--- a/src/components/FormProvider/initialValues.js
+++ b/src/components/FormProvider/initialValues.js
@@ -1,6 +1,12 @@
+const exposureInitialValues = {
+  locationsTraveledTo: [''],
+  heathCareWorker: '',
+  historyInChinaHealthcareFacility: '',
+  travelOutsideUS: ''
+};
+
 // DateField names need to be null, all other can be ''
 const initialValues = {
-  // identifiers
   knownContact: '',
   contactId: '',
   reportingJurisdiction: '',
@@ -88,7 +94,8 @@ const initialValues = {
   symptomAbdominalPain: '',
   symptomDiarrhea: '',
   symptomOther: '',
-  symptomOtherSpecify: ''
+  symptomOtherSpecify: '',
+  ...exposureInitialValues
 };
 
 export default initialValues;

--- a/src/components/FormProvider/initialValues.js
+++ b/src/components/FormProvider/initialValues.js
@@ -3,7 +3,9 @@ const exposureInitialValues = {
   heathCareWorker: '',
   historyInChinaHealthcareFacility: '',
   travelOutsideUS: '',
-  nonUSCountryNames: ['']
+  travelToChina: '',
+  chinaLocationsTraveledTo: [''],
+  travelToNonUS: ['']
 };
 
 // DateField names need to be null, all other can be ''

--- a/src/components/FormProvider/initialValues.js
+++ b/src/components/FormProvider/initialValues.js
@@ -5,7 +5,16 @@ const exposureInitialValues = {
   travelOutsideUS: '',
   travelToChina: '',
   chinaLocationsTraveledTo: [''],
-  travelToNonUS: ['']
+  travelToNonUS: [''],
+  contactWithCOVIDpatient: '',
+  sourceOfContact: [''],
+  healthcareContact: '',
+  sourceContactUSCase: '',
+  sourceContactCaseID: '',
+  animalExposure: '',
+  exposureToCluster: '',
+  sourceNotListed: '',
+  sourceNotListedSource: ''
 };
 
 // DateField names need to be null, all other can be ''

--- a/src/components/FormProvider/initialValues.js
+++ b/src/components/FormProvider/initialValues.js
@@ -2,7 +2,8 @@ const exposureInitialValues = {
   locationsTraveledTo: [''],
   heathCareWorker: '',
   historyInChinaHealthcareFacility: '',
-  travelOutsideUS: ''
+  travelOutsideUS: '',
+  nonUSCountryNames: ['']
 };
 
 // DateField names need to be null, all other can be ''

--- a/src/components/forms/MultipleSelections/MultipleSelections.js
+++ b/src/components/forms/MultipleSelections/MultipleSelections.js
@@ -2,7 +2,6 @@ import React, { useCallback, useMemo } from 'react';
 import { FieldArray, useFormikContext } from 'formik';
 import { faMinusSquare, faPlusSquare } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import Grid from '@material-ui/core/Grid';
 
 import useStyles from './styles';
 
@@ -26,21 +25,32 @@ function withMultipleSelections(SelectionComponent, WrapperComponent) {
     }, []);
 
     const indexOptions = useCallback(
-      index => {
-        return options.filter(location => {
-          return values[name][index] === location.value || values[name].indexOf(location.value) < 0;
-        });
-      },
+      options
+        ? index => {
+            return options.filter(location => {
+              return (
+                values[name][index] === location.value || values[name].indexOf(location.value) < 0
+              );
+            });
+          }
+        : index => options,
       [name, options, values]
     );
 
     const lastIcon = useCallback(
-      helpers => {
-        const icon = [minusIcon(helpers, values[name].length - 1)];
-        if (values[name].slice(-1)[0] && indexOptions(values[name].length - 1).length > 1)
-          return icon.concat(plusIcon(helpers, values[name].length - 1));
-        return icon;
-      },
+      options
+        ? helpers => {
+            const icon = [minusIcon(helpers, values[name].length - 1)];
+            if (values[name].slice(-1)[0] && indexOptions(values[name].length - 1).length > 1)
+              return icon.concat(plusIcon(helpers, values[name].length - 1));
+            return icon;
+          }
+        : helpers => {
+            return [
+              minusIcon(helpers, values[name].length - 1),
+              plusIcon(helpers, values[name].length - 1)
+            ];
+          },
       [indexOptions, minusIcon, name, plusIcon, values]
     );
 
@@ -91,9 +101,6 @@ function withMultipleSelections(SelectionComponent, WrapperComponent) {
 function withIcons(WrappedComponent, wrapperComponent) {
   return ({ withIcon, ...wrappedProps }) => {
     const styles = useStyles();
-    const wrappedComponent = useMemo(() => {
-      return <WrappedComponent {...wrappedProps} />;
-    }, [wrappedProps]);
 
     const icons = useMemo(() => {
       return (
@@ -112,6 +119,10 @@ function withIcons(WrappedComponent, wrapperComponent) {
         </>
       );
     }, [styles.icon, withIcon]);
+
+    const wrappedComponent = useMemo(() => {
+      return <WrappedComponent icons={icons} {...wrappedProps} />;
+    }, [wrappedProps]);
 
     return wrapperComponent
       ? React.cloneElement(wrapperComponent, { icons }, wrappedComponent)

--- a/src/components/forms/MultipleSelections/MultipleSelections.js
+++ b/src/components/forms/MultipleSelections/MultipleSelections.js
@@ -7,7 +7,7 @@ import useStyles from './styles';
 import Grid from '@material-ui/core/Grid';
 
 function withMultipleSelections(SelectionComponent, WrapperComponent = <MultiSelectWrapper />) {
-  return ({ name, label, options }) => {
+  return ({ name, options, ...props }) => {
     const SelectionComponentWithIcons = useMemo(() => {
       return withIcons(SelectionComponent, WrapperComponent);
     }, []);
@@ -57,8 +57,8 @@ function withMultipleSelections(SelectionComponent, WrapperComponent = <MultiSel
         render={arrayHelpers => (
           <>
             <SelectionComponentWithIcons
+              {...props}
               name={`${name}.0`}
-              label={label}
               withIcon={
                 values[name].length > 1
                   ? values[name][1] && minusIcon(arrayHelpers, 0)
@@ -72,16 +72,16 @@ function withMultipleSelections(SelectionComponent, WrapperComponent = <MultiSel
                 .map((location, index) => (
                   <SelectionComponentWithIcons
                     key={index.toString()}
+                    {...props}
                     name={`${name}.${index + 1}`}
-                    label={label}
                     withIcon={minusIcon(arrayHelpers, index + 1)}
                     options={indexOptions(index + 1)}
                   />
                 ))}
             {values[name].length > 1 && (
               <SelectionComponentWithIcons
+                {...props}
                 name={`${name}.${values[name].length - 1}`}
-                label={label}
                 withIcon={lastIcon(arrayHelpers)}
                 options={indexOptions(values[name].length - 1)}
               />
@@ -129,12 +129,14 @@ function withIcons(WrappedComponent, wrapperComponent) {
 
 function MultiSelectWrapper({ children, icons }) {
   const styles = useStyles();
+
   return (
     <Grid container alignItems="center" className={styles.multSelectWrapper} wrap="nowrap">
-      <Grid item className={styles.marginBottom} xs={11}>
+      <Grid item xs={11} className={styles.marginBottom}>
         {children}
       </Grid>
-      <Grid item container wrap="nowrap" xs={1}>
+
+      <Grid item xs={1} container wrap="nowrap">
         {icons}
       </Grid>
     </Grid>

--- a/src/components/forms/MultipleSelections/MultipleSelections.js
+++ b/src/components/forms/MultipleSelections/MultipleSelections.js
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { memo, useCallback, useMemo } from 'react';
 import { FieldArray, useFormikContext } from 'formik';
 import { faMinusSquare, faPlusSquare } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -7,14 +7,10 @@ import useStyles from './styles';
 
 function withMultipleSelections(SelectionComponent, WrapperComponent) {
   return ({ name, label, options }) => {
-    const SelectionComponentWithIcons = withIcons(SelectionComponent, WrapperComponent);
-    const { values } = useFormikContext();
-
-    const onChange = useCallback((helpers, index) => {
-      return event => {
-        helpers.replace(index, event.target.value);
-      };
+    const SelectionComponentWithIcons = useMemo(() => {
+      return withIcons(SelectionComponent, WrapperComponent);
     }, []);
+    const { values } = useFormikContext();
 
     const plusIcon = useCallback((helpers, index) => {
       return { icon: faPlusSquare, onClick: () => helpers.insert(index + 1, '') };
@@ -51,7 +47,7 @@ function withMultipleSelections(SelectionComponent, WrapperComponent) {
               plusIcon(helpers, values[name].length - 1)
             ];
           },
-      [indexOptions, minusIcon, name, plusIcon, values]
+      [indexOptions, minusIcon, name, plusIcon]
     );
 
     return (
@@ -67,7 +63,6 @@ function withMultipleSelections(SelectionComponent, WrapperComponent) {
                   ? values[name][1] && minusIcon(arrayHelpers, 0)
                   : values[name][0] && plusIcon(arrayHelpers, 0)
               }
-              onChange={onChange(arrayHelpers, 0)}
               options={indexOptions(0)}
             />
             {values[name] &&
@@ -79,7 +74,6 @@ function withMultipleSelections(SelectionComponent, WrapperComponent) {
                     name={`${name}.${index + 1}`}
                     label={label}
                     withIcon={minusIcon(arrayHelpers, index + 1)}
-                    onChange={onChange(arrayHelpers, index + 1)}
                     options={indexOptions(index + 1)}
                   />
                 ))}
@@ -122,10 +116,12 @@ function withIcons(WrappedComponent, wrapperComponent) {
 
     const wrappedComponent = useMemo(() => {
       return <WrappedComponent icons={icons} {...wrappedProps} />;
-    }, [wrappedProps]);
+    }, [icons, wrappedProps]);
 
     return wrapperComponent
-      ? React.cloneElement(wrapperComponent, { icons }, wrappedComponent)
+      ? useMemo(() => {
+          return React.cloneElement(wrapperComponent, { icons }, wrappedComponent);
+        }, [icons, wrappedComponent])
       : wrappedComponent;
   };
 }

--- a/src/components/forms/MultipleSelections/MultipleSelections.js
+++ b/src/components/forms/MultipleSelections/MultipleSelections.js
@@ -1,11 +1,12 @@
-import React, { memo, useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { FieldArray, useFormikContext } from 'formik';
 import { faMinusSquare, faPlusSquare } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import useStyles from './styles';
+import Grid from '@material-ui/core/Grid';
 
-function withMultipleSelections(SelectionComponent, WrapperComponent) {
+function withMultipleSelections(SelectionComponent, WrapperComponent = <MultiSelectWrapper />) {
   return ({ name, label, options }) => {
     const SelectionComponentWithIcons = useMemo(() => {
       return withIcons(SelectionComponent, WrapperComponent);
@@ -124,6 +125,20 @@ function withIcons(WrappedComponent, wrapperComponent) {
         }, [icons, wrappedComponent])
       : wrappedComponent;
   };
+}
+
+function MultiSelectWrapper({ children, icons }) {
+  const styles = useStyles();
+  return (
+    <Grid container alignItems="center" className={styles.multSelectWrapper} wrap="nowrap">
+      <Grid item className={styles.marginBottom} xs={11}>
+        {children}
+      </Grid>
+      <Grid item container wrap="nowrap" xs={1}>
+        {icons}
+      </Grid>
+    </Grid>
+  );
 }
 
 export default withMultipleSelections;

--- a/src/components/forms/MultipleSelections/MultipleSelections.js
+++ b/src/components/forms/MultipleSelections/MultipleSelections.js
@@ -1,0 +1,122 @@
+import React, { useCallback, useMemo } from 'react';
+import { FieldArray, useFormikContext } from 'formik';
+import { faMinusSquare, faPlusSquare } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import Grid from '@material-ui/core/Grid';
+
+import useStyles from './styles';
+
+function withMultipleSelections(SelectionComponent, WrapperComponent) {
+  return ({ name, label, options }) => {
+    const SelectionComponentWithIcons = withIcons(SelectionComponent, WrapperComponent);
+    const { values } = useFormikContext();
+
+    const onChange = useCallback((helpers, index) => {
+      return event => {
+        helpers.replace(index, event.target.value);
+      };
+    }, []);
+
+    const plusIcon = useCallback((helpers, index) => {
+      return { icon: faPlusSquare, onClick: () => helpers.insert(index + 1, '') };
+    }, []);
+
+    const minusIcon = useCallback((helpers, index) => {
+      return { icon: faMinusSquare, onClick: () => helpers.remove(index) };
+    }, []);
+
+    const indexOptions = useCallback(
+      index => {
+        return options.filter(location => {
+          return values[name][index] === location.value || values[name].indexOf(location.value) < 0;
+        });
+      },
+      [name, options, values]
+    );
+
+    const lastIcon = useCallback(
+      helpers => {
+        const icon = [minusIcon(helpers, values[name].length - 1)];
+        if (values[name].slice(-1)[0] && indexOptions(values[name].length - 1).length > 1)
+          return icon.concat(plusIcon(helpers, values[name].length - 1));
+        return icon;
+      },
+      [indexOptions, minusIcon, name, plusIcon, values]
+    );
+
+    return (
+      <FieldArray
+        name={name}
+        render={arrayHelpers => (
+          <>
+            <SelectionComponentWithIcons
+              name={`${name}.0`}
+              label={label}
+              withIcon={
+                values[name].length > 1
+                  ? values[name][1] && minusIcon(arrayHelpers, 0)
+                  : values[name][0] && plusIcon(arrayHelpers, 0)
+              }
+              onChange={onChange(arrayHelpers, 0)}
+              options={indexOptions(0)}
+            />
+            {values[name] &&
+              values[name]
+                .slice(1, values[name].length - 1)
+                .map((location, index) => (
+                  <SelectionComponentWithIcons
+                    key={index.toString()}
+                    name={`${name}.${index + 1}`}
+                    label={label}
+                    withIcon={minusIcon(arrayHelpers, index + 1)}
+                    onChange={onChange(arrayHelpers, index + 1)}
+                    options={indexOptions(index + 1)}
+                  />
+                ))}
+            {values[name].length > 1 && (
+              <SelectionComponentWithIcons
+                name={`${name}.${values[name].length - 1}`}
+                label={label}
+                withIcon={lastIcon(arrayHelpers)}
+                options={indexOptions(values[name].length - 1)}
+              />
+            )}
+          </>
+        )}
+      />
+    );
+  };
+}
+
+function withIcons(WrappedComponent, wrapperComponent) {
+  return ({ withIcon, ...wrappedProps }) => {
+    const styles = useStyles();
+    const wrappedComponent = useMemo(() => {
+      return <WrappedComponent {...wrappedProps} />;
+    }, [wrappedProps]);
+
+    const icons = useMemo(() => {
+      return (
+        <>
+          {withIcon &&
+            [withIcon]
+              .flat()
+              .map(({ icon, onClick }, index) => (
+                <FontAwesomeIcon
+                  icon={icon}
+                  className={styles.icon}
+                  onClick={onClick}
+                  key={index}
+                />
+              ))}
+        </>
+      );
+    }, [styles.icon, withIcon]);
+
+    return wrapperComponent
+      ? React.cloneElement(wrapperComponent, { icons }, wrappedComponent)
+      : wrappedComponent;
+  };
+}
+
+export default withMultipleSelections;

--- a/src/components/forms/MultipleSelections/styles.js
+++ b/src/components/forms/MultipleSelections/styles.js
@@ -7,7 +7,7 @@ export default makeStyles(
       cursor: 'pointer',
       marginLeft: '0.5em'
     },
-    container: {
+    multSelectWrapper: {
       marginBottom: '0.5em'
     }
   },

--- a/src/components/forms/MultipleSelections/styles.js
+++ b/src/components/forms/MultipleSelections/styles.js
@@ -8,7 +8,7 @@ export default makeStyles(
       marginLeft: '0.5em'
     },
     multSelectWrapper: {
-      marginBottom: '0.5em'
+      marginBottom: '1em'
     }
   },
   { name: 'MultipleSelections' }

--- a/src/components/forms/MultipleSelections/styles.js
+++ b/src/components/forms/MultipleSelections/styles.js
@@ -1,0 +1,15 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export default makeStyles(
+  {
+    icon: {
+      fontSize: '1.25em',
+      cursor: 'pointer',
+      marginLeft: '0.5em'
+    },
+    container: {
+      marginBottom: '0.5em'
+    }
+  },
+  { name: 'MultipleSelections' }
+);

--- a/src/components/forms/SelectBox/SelectBox.js
+++ b/src/components/forms/SelectBox/SelectBox.js
@@ -1,8 +1,9 @@
-import React, { useMemo } from 'react';
+import React, { memo, useMemo } from 'react';
 import { MenuItem } from '@material-ui/core';
 import TextField from 'components/forms/TextField';
+import withMultipleSelections from '../MultipleSelections/MultipleSelections';
 
-function SelectBox({ options, ...props }) {
+function StandardSelectBox({ options, ...props }) {
   const menuOptions = useMemo(
     () =>
       options.map(option => (
@@ -18,6 +19,12 @@ function SelectBox({ options, ...props }) {
       {menuOptions}
     </TextField>
   );
+}
+
+const MultipleSelectBox = memo(withMultipleSelections(SelectBox));
+
+function SelectBox({ allowMultiple, ...props }) {
+  return allowMultiple ? <MultipleSelectBox {...props} /> : <StandardSelectBox {...props} />;
 }
 
 export default SelectBox;

--- a/src/components/forms/TextField/TextField.js
+++ b/src/components/forms/TextField/TextField.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { memo } from 'react';
 import { Field } from 'formik';
 import { TextField as MUITextField } from '@material-ui/core';
 import { fieldToTextField } from 'formik-material-ui';
 import FormControl from 'components/forms/FormControl';
+import withMultipleSelections from '../MultipleSelections/MultipleSelections';
 
 export function FormikTextField({ children, onChange, ...props }) {
   const textFieldProps = fieldToTextField(props);
@@ -15,12 +16,18 @@ export function FormikTextField({ children, onChange, ...props }) {
   );
 }
 
-function TextField(props) {
+function StandardTextField(props) {
   return (
     <FormControl>
       <Field component={FormikTextField} {...props} />
     </FormControl>
   );
+}
+
+const MultipleTextField = memo(withMultipleSelections(TextField));
+
+function TextField({ allowMultiple, ...props }) {
+  return allowMultiple ? <MultipleTextField {...props} /> : <StandardTextField {...props} />;
 }
 
 export default TextField;

--- a/src/components/forms/index.js
+++ b/src/components/forms/index.js
@@ -1,8 +1,8 @@
-export { default as AutocompleteField } from './AutocompleteField';
+export { default as AutoCompleteField } from './AutocompleteField';
 export { default as DateField } from './DateField';
 export { default as FormControl } from './FormControl';
-export { FormGroup, FormGroupDivider } from './FormGroup';
 export { default as RadioField } from './RadioField';
 export { default as SelectBox } from './SelectBox';
 export { default as TelField } from './TelField';
 export { default as TextField } from './TextField';
+export { FormGroup, FormGroupDivider } from './FormGroup';

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -1,8 +1,6 @@
 import React, { memo, useMemo } from 'react';
 import Grid from '@material-ui/core/Grid';
-import { FieldArray, useFormikContext } from 'formik';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faMinusSquare, faPlusSquare } from '@fortawesome/free-solid-svg-icons';
+import { useFormikContext } from 'formik';
 
 import { FormGroup, FormGroupDivider, RadioField, SelectBox, TextField } from 'components/forms';
 import useStyles from './styles';

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -105,31 +105,14 @@ function LocationsTraveled() {
       helpers.replace(index, event.target.value);
     };
   }, []);
-  const onPlus = useCallback((helpers, index) => {
-    return () => {
-      helpers.insert(index + 1, '');
-    };
+
+  const plusIcon = useCallback((helpers, index) => {
+    return { icon: faPlusSquare, onClick: () => helpers.insert(index + 1, '') };
   }, []);
 
-  const onMinus = useCallback((helpers, index) => {
-    return () => {
-      helpers.remove(index);
-    };
+  const minusIcon = useCallback((helpers, index) => {
+    return { icon: faMinusSquare, onClick: () => helpers.remove(index) };
   }, []);
-
-  const plusIcon = useCallback(
-    (helpers, index) => {
-      return { icon: faPlusSquare, onClick: onPlus(helpers, index) };
-    },
-    [onPlus]
-  );
-
-  const minusIcon = useCallback(
-    (helpers, index) => {
-      return { icon: faMinusSquare, onClick: onMinus(helpers, index) };
-    },
-    [onMinus]
-  );
 
   return (
     <FieldArray

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -137,7 +137,7 @@ function LocationsTraveled() {
             name={`${name}.0`}
             withIcon={
               values[name].length > 1
-                ? minusIcon(arrayHelpers, 0)
+                ? values[name][1] && minusIcon(arrayHelpers, 0)
                 : values[name][0] && plusIcon(arrayHelpers, 0)
             }
             onChange={onChange(arrayHelpers, 0)}

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -70,19 +70,26 @@ function ExposureSection() {
           />
         </Grid>
         {values.travelOutsideUS === 'yes' && (
-          <Grid container alignItems="center">
-            <Grid item xs={6}>
-              <SelectBox
-                name="locationTraveledTo"
-                label="Location Traveled To"
-                options={locationOptions}
-              />
-            </Grid>
-            <FontAwesomeIcon icon={faPlusSquare} className={styles.plusIcon} />
-          </Grid>
+          <LocationsTraveled />
         )}
       </FormGroup>
     </>
+  );
+}
+
+function LocationsTraveled() {
+  const styles = useStyles();
+  return (
+    <Grid container alignItems="center">
+      <Grid item xs={6}>
+        <SelectBox
+          name="locationTraveledTo"
+          label="Location Traveled To"
+          options={locationOptions}
+        />
+      </Grid>
+      <FontAwesomeIcon icon={faPlusSquare} className={styles.plusIcon} />
+    </Grid>
   );
 }
 

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -6,6 +6,7 @@ import { faMinusSquare, faPlusSquare } from '@fortawesome/free-solid-svg-icons';
 
 import { FormGroup, FormGroupDivider, RadioField, SelectBox } from 'components/forms';
 import useStyles from './styles';
+import withMultipleSelections from 'components/forms/MultipleSelections/MultipleSelections';
 
 const options = [
   { value: 'yes', label: 'Yes' },
@@ -19,6 +20,20 @@ const locationOptions = [
   { value: 'mainlandChina', label: 'Mainland China' },
   { value: 'nonUSCountry', label: 'Non-US Country' }
 ];
+
+function GridWrapper({ children, icons }) {
+  const styles = useStyles();
+  return (
+    <Grid container alignItems="center" className={styles.locationSelection}>
+      <Grid item xs={6}>
+        {children}
+      </Grid>
+      {icons}
+    </Grid>
+  );
+}
+
+const LocationsTraveled = withMultipleSelections(SelectBox, <GridWrapper />);
 
 function ExposureSection() {
   const styles = useStyles();
@@ -69,102 +84,15 @@ function ExposureSection() {
             inFormGroup
           />
         </Grid>
-        {values.travelOutsideUS === 'yes' && <LocationsTraveled />}
+        {values.travelOutsideUS === 'yes' && (
+          <LocationsTraveled
+            name="locationsTraveledTo"
+            options={locationOptions}
+            label="Location Traveled To"
+          />
+        )}
       </FormGroup>
     </>
-  );
-}
-
-function LocationSelection({ name, withIcon, onChange, options }) {
-  const styles = useStyles();
-  return (
-    <Grid container alignItems="center" className={styles.locationSelection}>
-      <Grid item xs={6}>
-        <SelectBox name={name} label="Location Traveled To" options={options} onChange={onChange} />
-      </Grid>
-      {withIcon &&
-        [withIcon]
-          .flat()
-          .map(({ icon, onClick }, index) => (
-            <FontAwesomeIcon icon={icon} className={styles.icon} onClick={onClick} key={index} />
-          ))}
-    </Grid>
-  );
-}
-
-function LocationsTraveled() {
-  const { values } = useFormikContext();
-  const name = 'locationsTraveledTo';
-  const onChange = useCallback((helpers, index) => {
-    return event => {
-      helpers.replace(index, event.target.value);
-    };
-  }, []);
-
-  const plusIcon = useCallback((helpers, index) => {
-    return { icon: faPlusSquare, onClick: () => helpers.insert(index + 1, '') };
-  }, []);
-
-  const minusIcon = useCallback((helpers, index) => {
-    return { icon: faMinusSquare, onClick: () => helpers.remove(index) };
-  }, []);
-
-  const indexOptions = useCallback(
-    index => {
-      return locationOptions.filter(location => {
-        return values[name][index] === location.value || values[name].indexOf(location.value) < 0;
-      });
-    },
-    [values]
-  );
-
-  const lastIcon = useCallback(
-    helpers => {
-      const icon = [minusIcon(helpers, values[name].length - 1)];
-      if (values[name].slice(-1)[0] && indexOptions(values[name].length - 1).length > 1)
-        return icon.concat(plusIcon(helpers, values[name].length - 1));
-      return icon;
-    },
-    [indexOptions, minusIcon, plusIcon, values]
-  );
-
-  return (
-    <FieldArray
-      name={name}
-      render={arrayHelpers => (
-        <>
-          <LocationSelection
-            name={`${name}.0`}
-            withIcon={
-              values[name].length > 1
-                ? values[name][1] && minusIcon(arrayHelpers, 0)
-                : values[name][0] && plusIcon(arrayHelpers, 0)
-            }
-            onChange={onChange(arrayHelpers, 0)}
-            options={indexOptions(0)}
-          />
-          {values.locationsTraveledTo &&
-            values.locationsTraveledTo
-              .slice(1, values.locationsTraveledTo.length - 1)
-              .map((location, index) => (
-                <LocationSelection
-                  key={index.toString()}
-                  name={`${name}.${index + 1}`}
-                  withIcon={minusIcon(arrayHelpers, index + 1)}
-                  onChange={onChange(arrayHelpers, index + 1)}
-                  options={indexOptions(index + 1)}
-                />
-              ))}
-          {values[name].length > 1 && (
-            <LocationSelection
-              name={`${name}.${values[name].length - 1}`}
-              withIcon={lastIcon(arrayHelpers)}
-              options={indexOptions(values[name].length - 1)}
-            />
-          )}
-        </>
-      )}
-    />
   );
 }
 

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -106,6 +106,12 @@ function ExposureSection() {
                 Did the patient <strong>travel to another Non-US Country</strong>?
               </>
             }
+            onChange={e => {
+              batch(() => {
+                handleChange(e);
+                setFieldValue('travelToNonUS', ['']);
+              });
+            }}
             options={options}
             inFormGroup
           />
@@ -135,23 +141,34 @@ function ExposureSection() {
               </>
             }
             options={options}
+            onChange={e => {
+              batch(() => {
+                handleChange(e);
+                setFieldValue('sourceOfContact', ['']);
+                setFieldValue('healthcareContact', '');
+                setFieldValue('sourceContactUSCase', '');
+                setFieldValue('sourceContactCaseID', '');
+              });
+            }}
             inFormGroup
           />
         </Grid>
         {values.contactWithCOVIDpatient === 'yes' && (
-          <Grid container direction="column">
-            <Grid item xs={6}>
-              <SelectBox
-                name="sourceOfContact"
-                label="Source of Contact"
-                allowMultiple
-                options={sourceOfContactOptions}
-              />
+          <>
+            <Grid container direction="column">
+              <Grid item xs={6}>
+                <SelectBox
+                  name="sourceOfContact"
+                  label="Source of Contact"
+                  allowMultiple
+                  options={sourceOfContactOptions}
+                />
+              </Grid>
             </Grid>
-          </Grid>
+          </>
         )}
         {values.sourceOfContact.indexOf('healthcare') >= 0 && (
-          <Grid item xs={6}>
+          <Grid item xs={6} className={styles['margin-bottom']}>
             <SelectBox
               name="healthcareContact"
               label="Source of Healthcare Contact"
@@ -159,26 +176,30 @@ function ExposureSection() {
             />
           </Grid>
         )}
-
-        <FormGroupDivider />
-
         {values.contactWithCOVIDpatient === 'yes' && (
           <>
+            <FormGroupDivider />
+
             <Grid item xs={12}>
               <RadioField
                 name="sourceContactUSCase"
                 label={<>Was this COVID-19 source case-patient a U.S. case?</>}
                 options={options}
+                onChange={e => {
+                  batch(() => {
+                    handleChange(e);
+                    setFieldValue('sourceContactCaseID', '');
+                  });
+                }}
                 inFormGroup
               />
             </Grid>
             {values.sourceContactUSCase === 'yes' && (
-              <Grid container direction="column">
+              <Grid container direction="column" className={styles['margin-bottom']}>
                 <Grid item xs={6}>
                   <TextField
                     name="sourceContactCaseID"
                     label="nCoV ID of Source Case"
-                    allowMultiple
                     options={sourceOfContactOptions}
                   />
                 </Grid>
@@ -231,6 +252,12 @@ function ExposureSection() {
                 Was the patient <strong>exposed from a source not listed here</strong>?
               </>
             }
+            onChange={e => {
+              batch(() => {
+                handleChange(e);
+                setFieldValue('sourceNotListedSource', '');
+              });
+            }}
             options={options}
             inFormGroup
           />

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -75,42 +75,10 @@ function ExposureSection() {
   );
 }
 
-function LocationsTraveled() {
-  const { values } = useFormikContext();
-  const name = 'locationsTraveledTo';
-  const onChange = useCallback((helpers, index) => {
-    return event => {
-      helpers.replace(index, event.target.value);
-    };
-  }, []);
-  return (
-    <FieldArray
-      name={name}
-      render={arrayHelpers => (
-        <>
-          <div>asdf</div>
-          <LocationSelection
-            name={`${name}.0`}
-            withIcon={faPlusSquare}
-            onChange={onChange(arrayHelpers, 0)}
-          />
-          {/*{values.locationsTraveledTo &&*/}
-          {/*  values.locationsTraveledTo.map((location, index) => (*/}
-          {/*    <LocationsTraveled*/}
-          {/*      name={`${name}.${index}`}*/}
-          {/*      onChange={onChange(arrayHelpers, index)}*/}
-          {/*    />*/}
-          {/*  ))}*/}
-        </>
-      )}
-    />
-  );
-}
-
-function LocationSelection({ name, withIcon, onChange }) {
+function LocationSelection({ name, withIcon, onChange, onClick }) {
   const styles = useStyles();
   return (
-    <Grid container alignItems="center">
+    <Grid container alignItems="center" className={styles.locationSelection}>
       <Grid item xs={6}>
         <SelectBox
           name={name}
@@ -119,8 +87,84 @@ function LocationSelection({ name, withIcon, onChange }) {
           onChange={onChange}
         />
       </Grid>
-      {withIcon && <FontAwesomeIcon icon={withIcon} className={styles.plusIcon} />}
+      {withIcon &&
+        [withIcon]
+          .flat()
+          .map(({ icon, onClick }) => (
+            <FontAwesomeIcon icon={icon} className={styles.icon} onClick={onClick} />
+          ))}
     </Grid>
+  );
+}
+
+function LocationsTraveled() {
+  const { values } = useFormikContext();
+  const name = 'locationsTraveledTo';
+  const onChange = useCallback((helpers, index) => {
+    return event => {
+      helpers.replace(index, event.target.value);
+    };
+  }, []);
+  const onPlus = useCallback((helpers, index) => {
+    return () => {
+      helpers.insert(index + 1, '');
+    };
+  }, []);
+
+  const onMinus = useCallback((helpers, index) => {
+    return () => {
+      helpers.remove(index);
+    };
+  }, []);
+
+  const plusIcon = useCallback(
+    (helpers, index) => {
+      return { icon: faPlusSquare, onClick: onPlus(helpers, index) };
+    },
+    [onPlus]
+  );
+
+  const minusIcon = useCallback(
+    (helpers, index) => {
+      return { icon: faMinusSquare, onClick: onMinus(helpers, index) };
+    },
+    [onMinus]
+  );
+
+  return (
+    <FieldArray
+      name={name}
+      render={arrayHelpers => (
+        <>
+          <LocationSelection
+            name={`${name}.0`}
+            withIcon={
+              values[name].length > 1 ? minusIcon(arrayHelpers, 0) : plusIcon(arrayHelpers, 0)
+            }
+            onChange={onChange(arrayHelpers, 0)}
+          />
+          {values.locationsTraveledTo &&
+            values.locationsTraveledTo
+              .slice(1, values.locationsTraveledTo.length - 1)
+              .map((location, index) => (
+                <LocationSelection
+                  name={`${name}.${index + 1}`}
+                  withIcon={minusIcon(arrayHelpers, index + 1)}
+                  onChange={onChange(arrayHelpers, index + 1)}
+                />
+              ))}
+          {values[name].length > 1 && (
+            <LocationSelection
+              name={`${name}.${values[name].length - 1}`}
+              withIcon={[
+                minusIcon(arrayHelpers, values[name].length - 1),
+                plusIcon(arrayHelpers, values[name].length - 1)
+              ]}
+            />
+          )}
+        </>
+      )}
+    />
   );
 }
 

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import Grid from '@material-ui/core/Grid';
-import { useFormikContext } from 'formik';
+import { FieldArray, useFormikContext } from 'formik';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPlusSquare } from '@fortawesome/free-solid-svg-icons';
+import { faPlusSquare, faMinusSquare } from '@fortawesome/free-solid-svg-icons';
 
 import { RadioField, FormGroup, FormGroupDivider, SelectBox } from 'components/forms';
 import useStyles from './styles';
@@ -69,26 +69,57 @@ function ExposureSection() {
             inFormGroup
           />
         </Grid>
-        {values.travelOutsideUS === 'yes' && (
-          <LocationsTraveled />
-        )}
+        {values.travelOutsideUS === 'yes' && <LocationsTraveled />}
       </FormGroup>
     </>
   );
 }
 
 function LocationsTraveled() {
+  const { values } = useFormikContext();
+  const name = 'locationsTraveledTo';
+  const onChange = useCallback((helpers, index) => {
+    return event => {
+      helpers.replace(index, event.target.value);
+    };
+  }, []);
+  return (
+    <FieldArray
+      name={name}
+      render={arrayHelpers => (
+        <>
+          <div>asdf</div>
+          <LocationSelection
+            name={`${name}.0`}
+            withIcon={faPlusSquare}
+            onChange={onChange(arrayHelpers, 0)}
+          />
+          {/*{values.locationsTraveledTo &&*/}
+          {/*  values.locationsTraveledTo.map((location, index) => (*/}
+          {/*    <LocationsTraveled*/}
+          {/*      name={`${name}.${index}`}*/}
+          {/*      onChange={onChange(arrayHelpers, index)}*/}
+          {/*    />*/}
+          {/*  ))}*/}
+        </>
+      )}
+    />
+  );
+}
+
+function LocationSelection({ name, withIcon, onChange }) {
   const styles = useStyles();
   return (
     <Grid container alignItems="center">
       <Grid item xs={6}>
         <SelectBox
-          name="locationTraveledTo"
+          name={name}
           label="Location Traveled To"
           options={locationOptions}
+          onChange={onChange}
         />
       </Grid>
-      <FontAwesomeIcon icon={faPlusSquare} className={styles.plusIcon} />
+      {withIcon && <FontAwesomeIcon icon={withIcon} className={styles.plusIcon} />}
     </Grid>
   );
 }

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { memo, useMemo } from 'react';
 import Grid from '@material-ui/core/Grid';
 import { FieldArray, useFormikContext } from 'formik';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -41,7 +41,7 @@ function TextSelectBox({ name, label, icons }) {
   );
 }
 
-const MultipleTextBox = withMultipleSelections(TextSelectBox, <GridWrapper />);
+const MultipleTextBox = memo(withMultipleSelections(TextSelectBox, <GridWrapper />));
 
 function LocationSelectBox({ name, label, options, icons }) {
   const { values } = useFormikContext();

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -1,9 +1,11 @@
 import React from 'react';
 import Grid from '@material-ui/core/Grid';
+import { useFormikContext } from 'formik';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faPlusSquare } from '@fortawesome/free-solid-svg-icons';
 
 import { RadioField, FormGroup, FormGroupDivider, SelectBox } from 'components/forms';
 import useStyles from './styles';
-import { useFormikContext } from 'formik';
 
 const options = [
   { value: 'yes', label: 'Yes' },
@@ -20,7 +22,7 @@ const locationOptions = [
 
 function ExposureSection() {
   const styles = useStyles();
-  const { values, setFieldValue } = useFormikContext();
+  const { values } = useFormikContext();
   return (
     <>
       <FormGroup options={options}>
@@ -68,13 +70,15 @@ function ExposureSection() {
           />
         </Grid>
         {values.travelOutsideUS === 'yes' && (
-          <Grid item xs={6}>
-            <SelectBox
-              name="locationTraveledTo"
-              label="Location Traveled To"
-              options={locationOptions}
-            />
-
+          <Grid container alignItems="center">
+            <Grid item xs={6}>
+              <SelectBox
+                name="locationTraveledTo"
+                label="Location Traveled To"
+                options={locationOptions}
+              />
+            </Grid>
+            <FontAwesomeIcon icon={faPlusSquare} className={styles.plusIcon} />
           </Grid>
         )}
       </FormGroup>

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -1,10 +1,10 @@
-import React, { useCallback } from 'react';
+import React, { useMemo } from 'react';
 import Grid from '@material-ui/core/Grid';
 import { FieldArray, useFormikContext } from 'formik';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faMinusSquare, faPlusSquare } from '@fortawesome/free-solid-svg-icons';
 
-import { FormGroup, FormGroupDivider, RadioField, SelectBox } from 'components/forms';
+import { FormGroup, FormGroupDivider, RadioField, SelectBox, TextField } from 'components/forms';
 import useStyles from './styles';
 import withMultipleSelections from 'components/forms/MultipleSelections/MultipleSelections';
 
@@ -25,15 +25,44 @@ function GridWrapper({ children, icons }) {
   const styles = useStyles();
   return (
     <Grid container alignItems="center" className={styles.locationSelection}>
-      <Grid item xs={6}>
-        {children}
-      </Grid>
-      {icons}
+      {children}
     </Grid>
   );
 }
 
-const LocationsTraveled = withMultipleSelections(SelectBox, <GridWrapper />);
+function TextSelectBox({ name, label, icons }) {
+  return (
+    <>
+      <Grid item xs={6}>
+        <TextField name={name} label={label} type="text" autoComplete="off" />
+      </Grid>
+      {icons}
+    </>
+  );
+}
+
+const MultipleTextBox = withMultipleSelections(TextSelectBox, <GridWrapper />);
+
+function LocationSelectBox({ name, label, options, icons }) {
+  const { values } = useFormikContext();
+  const locationName = useMemo(() => {
+    return <MultipleTextBox name="nonUSCountryNames" label="Non-US Country Name" />;
+  }, []);
+  return (
+    <>
+      <Grid item xs={6}>
+        <SelectBox name={name} label={label} options={options} />
+      </Grid>
+      {icons}
+
+      {name.split('.').reduce((acc, index) => {
+        return acc[index];
+      }, values) === 'nonUSCountry' && locationName}
+    </>
+  );
+}
+
+const MultipleLocationSelection = withMultipleSelections(LocationSelectBox, <GridWrapper />);
 
 function ExposureSection() {
   const styles = useStyles();
@@ -85,7 +114,7 @@ function ExposureSection() {
           />
         </Grid>
         {values.travelOutsideUS === 'yes' && (
-          <LocationsTraveled
+          <MultipleLocationSelection
             name="locationsTraveledTo"
             options={locationOptions}
             label="Location Traveled To"

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -2,9 +2,9 @@ import React, { useCallback } from 'react';
 import Grid from '@material-ui/core/Grid';
 import { FieldArray, useFormikContext } from 'formik';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faPlusSquare, faMinusSquare } from '@fortawesome/free-solid-svg-icons';
+import { faMinusSquare, faPlusSquare } from '@fortawesome/free-solid-svg-icons';
 
-import { RadioField, FormGroup, FormGroupDivider, SelectBox } from 'components/forms';
+import { FormGroup, FormGroupDivider, RadioField, SelectBox } from 'components/forms';
 import useStyles from './styles';
 
 const options = [
@@ -75,23 +75,18 @@ function ExposureSection() {
   );
 }
 
-function LocationSelection({ name, withIcon, onChange, onClick }) {
+function LocationSelection({ name, withIcon, onChange, options }) {
   const styles = useStyles();
   return (
     <Grid container alignItems="center" className={styles.locationSelection}>
       <Grid item xs={6}>
-        <SelectBox
-          name={name}
-          label="Location Traveled To"
-          options={locationOptions}
-          onChange={onChange}
-        />
+        <SelectBox name={name} label="Location Traveled To" options={options} onChange={onChange} />
       </Grid>
       {withIcon &&
         [withIcon]
           .flat()
-          .map(({ icon, onClick }) => (
-            <FontAwesomeIcon icon={icon} className={styles.icon} onClick={onClick} />
+          .map(({ icon, onClick }, index) => (
+            <FontAwesomeIcon icon={icon} className={styles.icon} onClick={onClick} key={index} />
           ))}
     </Grid>
   );
@@ -114,6 +109,15 @@ function LocationsTraveled() {
     return { icon: faMinusSquare, onClick: () => helpers.remove(index) };
   }, []);
 
+  const indexOptions = useCallback(
+    index => {
+      return locationOptions.filter(location => {
+        return values[name][index] === location.value || values[name].indexOf(location.value) < 0;
+      });
+    },
+    [values]
+  );
+
   return (
     <FieldArray
       name={name}
@@ -125,15 +129,18 @@ function LocationsTraveled() {
               values[name].length > 1 ? minusIcon(arrayHelpers, 0) : plusIcon(arrayHelpers, 0)
             }
             onChange={onChange(arrayHelpers, 0)}
+            options={indexOptions(0)}
           />
           {values.locationsTraveledTo &&
             values.locationsTraveledTo
               .slice(1, values.locationsTraveledTo.length - 1)
               .map((location, index) => (
                 <LocationSelection
+                  key={index.toString()}
                   name={`${name}.${index + 1}`}
                   withIcon={minusIcon(arrayHelpers, index + 1)}
                   onChange={onChange(arrayHelpers, index + 1)}
+                  options={indexOptions(index + 1)}
                 />
               ))}
           {values[name].length > 1 && (
@@ -143,6 +150,7 @@ function LocationsTraveled() {
                 minusIcon(arrayHelpers, values[name].length - 1),
                 plusIcon(arrayHelpers, values[name].length - 1)
               ]}
+              options={indexOptions(values[name].length - 1)}
             />
           )}
         </>

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -118,6 +118,16 @@ function LocationsTraveled() {
     [values]
   );
 
+  const lastIcon = useCallback(
+    helpers => {
+      const icon = [minusIcon(helpers, values[name].length - 1)];
+      if (values[name].slice(-1)[0] && indexOptions(values[name].length - 1).length > 1)
+        return icon.concat(plusIcon(helpers, values[name].length - 1));
+      return icon;
+    },
+    [indexOptions, minusIcon, plusIcon, values]
+  );
+
   return (
     <FieldArray
       name={name}
@@ -126,7 +136,9 @@ function LocationsTraveled() {
           <LocationSelection
             name={`${name}.0`}
             withIcon={
-              values[name].length > 1 ? minusIcon(arrayHelpers, 0) : plusIcon(arrayHelpers, 0)
+              values[name].length > 1
+                ? minusIcon(arrayHelpers, 0)
+                : values[name][0] && plusIcon(arrayHelpers, 0)
             }
             onChange={onChange(arrayHelpers, 0)}
             options={indexOptions(0)}
@@ -146,10 +158,7 @@ function LocationsTraveled() {
           {values[name].length > 1 && (
             <LocationSelection
               name={`${name}.${values[name].length - 1}`}
-              withIcon={[
-                minusIcon(arrayHelpers, values[name].length - 1),
-                plusIcon(arrayHelpers, values[name].length - 1)
-              ]}
+              withIcon={lastIcon(arrayHelpers)}
               options={indexOptions(values[name].length - 1)}
             />
           )}

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -33,6 +33,7 @@ const healthcareContactOptions = [
 function ExposureSection() {
   const styles = useStyles();
   const { values, handleChange, setFieldValue } = useFormikContext();
+
   return (
     <>
       <FormGroup options={options}>
@@ -48,7 +49,9 @@ function ExposureSection() {
             inFormGroup
           />
         </Grid>
+
         <FormGroupDivider />
+
         <Grid item xs={12} className={styles['margin-bottom']}>
           <RadioField
             name="historyInChinaHealthcareFacility"
@@ -66,6 +69,7 @@ function ExposureSection() {
           />
         </Grid>
       </FormGroup>
+
       <FormGroup options={options} headerText="In the 14 days prior to illness onset...">
         <Grid item xs={12}>
           <RadioField
@@ -85,9 +89,10 @@ function ExposureSection() {
             inFormGroup
           />
         </Grid>
+
         {values.travelToChina === 'yes' && (
           <Grid container direction="column">
-            <Grid item xs={6}>
+            <Grid item xs={4}>
               <SelectBox
                 name="chinaLocationsTraveledTo"
                 label="Location Traveled To"
@@ -98,12 +103,14 @@ function ExposureSection() {
           </Grid>
         )}
 
+        <FormGroupDivider />
+
         <Grid item xs={12}>
           <RadioField
             name="travelOutsideUS"
             label={
               <>
-                Did the patient <strong>travel to another Non-US Country</strong>?
+                Did the patient <strong>travel to a Non-US Country besides China</strong>?
               </>
             }
             onChange={e => {
@@ -116,15 +123,16 @@ function ExposureSection() {
             inFormGroup
           />
         </Grid>
+
         {values.travelOutsideUS === 'yes' && (
           <Grid container direction="column">
-            <Grid item xs={6}>
+            <Grid item xs={4}>
               <TextField
                 name="travelToNonUS"
                 label="Location Traveled To"
-                allowMultiple
                 type="text"
                 autoComplete="off"
+                allowMultiple
               />
             </Grid>
           </Grid>
@@ -153,29 +161,38 @@ function ExposureSection() {
             inFormGroup
           />
         </Grid>
+
         {values.contactWithCOVIDpatient === 'yes' && (
-          <>
-            <Grid container direction="column">
-              <Grid item xs={6}>
-                <SelectBox
-                  name="sourceOfContact"
-                  label="Source of Contact"
-                  allowMultiple
-                  options={sourceOfContactOptions}
-                />
-              </Grid>
+          <Grid container direction="column">
+            <Grid item xs={4}>
+              <SelectBox
+                name="sourceOfContact"
+                label="Source of Contact"
+                options={sourceOfContactOptions}
+                allowMultiple
+                onChange={e => {
+                  batch(() => {
+                    handleChange(e);
+                    setFieldValue('healthcareContact', '');
+                  });
+                }}
+              />
             </Grid>
-          </>
-        )}
-        {values.sourceOfContact.indexOf('healthcare') >= 0 && (
-          <Grid item xs={6} className={styles['margin-bottom']}>
-            <SelectBox
-              name="healthcareContact"
-              label="Source of Healthcare Contact"
-              options={healthcareContactOptions}
-            />
           </Grid>
         )}
+
+        {values.sourceOfContact.indexOf('healthcare') >= 0 && (
+          <Grid container item xs={4} direction="column">
+            <Grid item xs={11} className={styles['margin-bottom']}>
+              <SelectBox
+                name="healthcareContact"
+                label="Source of Healthcare Contact"
+                options={healthcareContactOptions}
+              />
+            </Grid>
+          </Grid>
+        )}
+
         {values.contactWithCOVIDpatient === 'yes' && (
           <>
             <FormGroupDivider />
@@ -194,9 +211,10 @@ function ExposureSection() {
                 inFormGroup
               />
             </Grid>
+
             {values.sourceContactUSCase === 'yes' && (
               <Grid container direction="column" className={styles['margin-bottom']}>
-                <Grid item xs={6}>
+                <Grid item xs={4}>
                   <TextField
                     name="sourceContactCaseID"
                     label="nCoV ID of Source Case"
@@ -263,9 +281,10 @@ function ExposureSection() {
           />
         </Grid>
       </FormGroup>
+
       {values.sourceNotListed === 'yes' && (
         <Grid container direction="column">
-          <Grid item xs={6}>
+          <Grid item xs={4}>
             <TextField name="sourceNotListedSource" label="Source of Exposure" />
           </Grid>
         </Grid>

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { unstable_batchedUpdates as batch } from 'react-dom';
 import Grid from '@material-ui/core/Grid';
 import { useFormikContext } from 'formik';
 
@@ -17,9 +18,21 @@ const locationOptions = [
   { value: 'mainlandChina', label: 'Mainland China' }
 ];
 
+const sourceOfContactOptions = [
+  { value: 'household', label: 'Household' },
+  { value: 'community', label: 'Community' },
+  { value: 'healthcare', label: 'Healthcare' }
+];
+
+const healthcareContactOptions = [
+  { value: 'patient', label: 'Patient' },
+  { value: 'visitor', label: 'Visitor' },
+  { value: 'healthcare worker', label: 'Healthcare Worker' }
+];
+
 function ExposureSection() {
   const styles = useStyles();
-  const { values } = useFormikContext();
+  const { values, handleChange, setFieldValue } = useFormikContext();
   return (
     <>
       <FormGroup options={options}>
@@ -63,6 +76,12 @@ function ExposureSection() {
               </>
             }
             options={options}
+            onChange={e => {
+              batch(() => {
+                handleChange(e);
+                setFieldValue('chinaLocationsTraveledTo', ['']);
+              });
+            }}
             inFormGroup
           />
         </Grid>
@@ -84,7 +103,7 @@ function ExposureSection() {
             name="travelOutsideUS"
             label={
               <>
-                Did the patient <strong>travel to another Non-US Country?</strong>?
+                Did the patient <strong>travel to another Non-US Country</strong>?
               </>
             }
             options={options}
@@ -104,7 +123,126 @@ function ExposureSection() {
             </Grid>
           </Grid>
         )}
+
+        <FormGroupDivider />
+
+        <Grid item xs={12}>
+          <RadioField
+            name="contactWithCOVIDpatient"
+            label={
+              <>
+                Did the patient come into <strong>contact with another COVID-19 patient</strong>?
+              </>
+            }
+            options={options}
+            inFormGroup
+          />
+        </Grid>
+        {values.contactWithCOVIDpatient === 'yes' && (
+          <Grid container direction="column">
+            <Grid item xs={6}>
+              <SelectBox
+                name="sourceOfContact"
+                label="Source of Contact"
+                allowMultiple
+                options={sourceOfContactOptions}
+              />
+            </Grid>
+          </Grid>
+        )}
+        {values.sourceOfContact.indexOf('healthcare') >= 0 && (
+          <Grid item xs={6}>
+            <SelectBox
+              name="healthcareContact"
+              label="Source of Healthcare Contact"
+              options={healthcareContactOptions}
+            />
+          </Grid>
+        )}
+
+        <FormGroupDivider />
+
+        {values.contactWithCOVIDpatient === 'yes' && (
+          <>
+            <Grid item xs={12}>
+              <RadioField
+                name="sourceContactUSCase"
+                label={<>Was this COVID-19 source case-patient a U.S. case?</>}
+                options={options}
+                inFormGroup
+              />
+            </Grid>
+            {values.sourceContactUSCase === 'yes' && (
+              <Grid container direction="column">
+                <Grid item xs={6}>
+                  <TextField
+                    name="sourceContactCaseID"
+                    label="nCoV ID of Source Case"
+                    allowMultiple
+                    options={sourceOfContactOptions}
+                  />
+                </Grid>
+              </Grid>
+            )}
+          </>
+        )}
+
+        <FormGroupDivider />
+
+        <Grid item xs={12}>
+          <RadioField
+            name="animalExposure"
+            label={
+              <>
+                Was the patient <strong>exposed from an animal</strong>?
+              </>
+            }
+            options={options}
+            inFormGroup
+          />
+        </Grid>
+
+        <FormGroupDivider />
+
+        <Grid item xs={12}>
+          <RadioField
+            name="exposureToCluster"
+            label={
+              <>
+                Was the patient{' '}
+                <strong>
+                  exposed to a cluster of patients with severe acute lower respiratory distress
+                </strong>{' '}
+                of unknown etiology?
+              </>
+            }
+            options={options}
+            inFormGroup
+          />
+        </Grid>
+
+        <FormGroupDivider />
+
+        <Grid item xs={12}>
+          <RadioField
+            name="sourceNotListed"
+            label={
+              <>
+                Was the patient <strong>exposed from a source not listed here</strong>?
+              </>
+            }
+            options={options}
+            inFormGroup
+          />
+        </Grid>
       </FormGroup>
+      {values.sourceNotListed === 'yes' && (
+        <Grid container direction="column">
+          <Grid item xs={6}>
+            <TextField name="sourceNotListedSource" label="Source of Exposure" />
+          </Grid>
+        </Grid>
+      )}
     </>
   );
 }

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import Grid from '@material-ui/core/Grid';
+
+import { RadioField, FormGroup, FormGroupDivider, SelectBox } from 'components/forms';
+import useStyles from './styles';
+import { useFormikContext } from 'formik';
+
+const options = [
+  { value: 'yes', label: 'Yes' },
+  { value: 'no', label: 'No' },
+  { value: 'unknown', label: 'Unknown' }
+];
+
+const locationOptions = [
+  { value: 'wuhan', label: 'Wuhan' },
+  { value: 'hubei', label: 'Hubei' },
+  { value: 'mainlandChina', label: 'Mainland China' },
+  { value: 'nonUSCountry', label: 'Non-US Country' }
+];
+
+function ExposureSection() {
+  const styles = useStyles();
+  const { values, setFieldValue } = useFormikContext();
+  return (
+    <>
+      <FormGroup options={options}>
+        <Grid item xs={12}>
+          <RadioField
+            name="heathCareWorker"
+            label={
+              <>
+                Is the patient a <strong> health care worker </strong> in the United States?
+              </>
+            }
+            options={options}
+            inFormGroup
+          />
+        </Grid>
+        <FormGroupDivider />
+        <Grid item xs={12} className={styles['margin-bottom']}>
+          <RadioField
+            name="historyInChinaHealthcareFacility"
+            label={
+              <>
+                {' '}
+                Does the patient have <strong>
+                  a history of being in a healthcare facility
+                </strong>{' '}
+                (as a patient, worker or vistor) <strong>in China</strong>?
+              </>
+            }
+            options={options}
+            inFormGroup
+          />
+        </Grid>
+      </FormGroup>
+      <FormGroup options={options} headerText="In the 14 days prior to illness onset...">
+        <Grid item xs={12}>
+          <RadioField
+            name="travelOutsideUS"
+            label={
+              <>
+                Did the patient <strong>travel outside of the US</strong>
+              </>
+            }
+            options={options}
+            inFormGroup
+          />
+        </Grid>
+        {values.travelOutsideUS === 'yes' && (
+          <Grid item xs={6}>
+            <SelectBox
+              name="locationTraveledTo"
+              label="Location Traveled To"
+              options={locationOptions}
+            />
+
+          </Grid>
+        )}
+      </FormGroup>
+    </>
+  );
+}
+
+export default ExposureSection;

--- a/src/components/sections/ExposureSection/ExposureSection.js
+++ b/src/components/sections/ExposureSection/ExposureSection.js
@@ -1,10 +1,9 @@
-import React, { memo, useMemo } from 'react';
+import React from 'react';
 import Grid from '@material-ui/core/Grid';
 import { useFormikContext } from 'formik';
 
 import { FormGroup, FormGroupDivider, RadioField, SelectBox, TextField } from 'components/forms';
 import useStyles from './styles';
-import withMultipleSelections from 'components/forms/MultipleSelections/MultipleSelections';
 
 const options = [
   { value: 'yes', label: 'Yes' },
@@ -15,52 +14,8 @@ const options = [
 const locationOptions = [
   { value: 'wuhan', label: 'Wuhan' },
   { value: 'hubei', label: 'Hubei' },
-  { value: 'mainlandChina', label: 'Mainland China' },
-  { value: 'nonUSCountry', label: 'Non-US Country' }
+  { value: 'mainlandChina', label: 'Mainland China' }
 ];
-
-function GridWrapper({ children, icons }) {
-  const styles = useStyles();
-  return (
-    <Grid container alignItems="center" className={styles.locationSelection}>
-      {children}
-    </Grid>
-  );
-}
-
-function TextSelectBox({ name, label, icons }) {
-  return (
-    <>
-      <Grid item xs={6}>
-        <TextField name={name} label={label} type="text" autoComplete="off" />
-      </Grid>
-      {icons}
-    </>
-  );
-}
-
-const MultipleTextBox = memo(withMultipleSelections(TextSelectBox, <GridWrapper />));
-
-function LocationSelectBox({ name, label, options, icons }) {
-  const { values } = useFormikContext();
-  const locationName = useMemo(() => {
-    return <MultipleTextBox name="nonUSCountryNames" label="Non-US Country Name" />;
-  }, []);
-  return (
-    <>
-      <Grid item xs={6}>
-        <SelectBox name={name} label={label} options={options} />
-      </Grid>
-      {icons}
-
-      {name.split('.').reduce((acc, index) => {
-        return acc[index];
-      }, values) === 'nonUSCountry' && locationName}
-    </>
-  );
-}
-
-const MultipleLocationSelection = withMultipleSelections(LocationSelectBox, <GridWrapper />);
 
 function ExposureSection() {
   const styles = useStyles();
@@ -101,10 +56,35 @@ function ExposureSection() {
       <FormGroup options={options} headerText="In the 14 days prior to illness onset...">
         <Grid item xs={12}>
           <RadioField
+            name="travelToChina"
+            label={
+              <>
+                Did the patient <strong>travel to China</strong>?
+              </>
+            }
+            options={options}
+            inFormGroup
+          />
+        </Grid>
+        {values.travelToChina === 'yes' && (
+          <Grid container direction="column">
+            <Grid item xs={6}>
+              <SelectBox
+                name="chinaLocationsTraveledTo"
+                label="Location Traveled To"
+                options={locationOptions}
+                allowMultiple
+              />
+            </Grid>
+          </Grid>
+        )}
+
+        <Grid item xs={12}>
+          <RadioField
             name="travelOutsideUS"
             label={
               <>
-                Did the patient <strong>travel outside of the US</strong>
+                Did the patient <strong>travel to another Non-US Country?</strong>?
               </>
             }
             options={options}
@@ -112,11 +92,17 @@ function ExposureSection() {
           />
         </Grid>
         {values.travelOutsideUS === 'yes' && (
-          <MultipleLocationSelection
-            name="locationsTraveledTo"
-            options={locationOptions}
-            label="Location Traveled To"
-          />
+          <Grid container direction="column">
+            <Grid item xs={6}>
+              <TextField
+                name="travelToNonUS"
+                label="Location Traveled To"
+                allowMultiple
+                type="text"
+                autoComplete="off"
+              />
+            </Grid>
+          </Grid>
         )}
       </FormGroup>
     </>

--- a/src/components/sections/ExposureSection/index.js
+++ b/src/components/sections/ExposureSection/index.js
@@ -1,0 +1,1 @@
+export { default } from './ExposureSection';

--- a/src/components/sections/ExposureSection/styles.js
+++ b/src/components/sections/ExposureSection/styles.js
@@ -5,10 +5,13 @@ export default makeStyles(
     'margin-bottom': {
       marginBottom: '1em'
     },
-    plusIcon: {
+    icon: {
       fontSize: '1.25em',
       cursor: 'pointer',
       marginLeft: '0.5em'
+    },
+    locationSelection: {
+      marginBottom: '0.5em'
     }
   },
   { name: 'ExposureSection' }

--- a/src/components/sections/ExposureSection/styles.js
+++ b/src/components/sections/ExposureSection/styles.js
@@ -1,0 +1,10 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export default makeStyles(
+  {
+    'margin-bottom': {
+      marginBottom: '1em'
+    }
+  },
+  { name: 'ExposureSection' }
+);

--- a/src/components/sections/ExposureSection/styles.js
+++ b/src/components/sections/ExposureSection/styles.js
@@ -4,6 +4,11 @@ export default makeStyles(
   {
     'margin-bottom': {
       marginBottom: '1em'
+    },
+    plusIcon: {
+      fontSize: '1.25em',
+      cursor: 'pointer',
+      marginLeft: '0.5em'
     }
   },
   { name: 'ExposureSection' }

--- a/src/components/sections/ExposureSection/styles.js
+++ b/src/components/sections/ExposureSection/styles.js
@@ -5,13 +5,8 @@ export default makeStyles(
     'margin-bottom': {
       marginBottom: '1em'
     },
-    icon: {
-      fontSize: '1.25em',
-      cursor: 'pointer',
-      marginLeft: '0.5em'
-    },
-    locationSelection: {
-      marginBottom: '0.5em'
+    'margin-top': {
+      marginTop: '1em'
     }
   },
   { name: 'ExposureSection' }

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,6 +972,32 @@
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.8.0.tgz#bbbff68978fefdbe68ccb533bc8cbe1d1afb5413"
   integrity sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==
 
+"@fortawesome/fontawesome-common-types@^0.2.27":
+  version "0.2.27"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.27.tgz#19706345859fc46adf3684ed01d11b40903b87e9"
+  integrity sha512-97GaByGaXDGMkzcJX7VmR/jRJd8h1mfhtA7RsxDBN61GnWE/PPCZhOdwG/8OZYktiRUF0CvFOr+VgRkJrt6TWg==
+
+"@fortawesome/fontawesome-svg-core@^1.2.27":
+  version "1.2.27"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.27.tgz#e4db8e3be81a40988213507c3e3d0c158a6641a3"
+  integrity sha512-sOD3DKynocnHYpuw2sLPnTunDj7rLk91LYhi2axUYwuGe9cPCw7Bsu9EWtVdNJP+IYgTCZIbyARKXuy5K/nv+Q==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.27"
+
+"@fortawesome/free-solid-svg-icons@^5.12.1":
+  version "5.12.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.12.1.tgz#76b6f958a3471821ff146f8f955e6d7cfe87147c"
+  integrity sha512-k3MwRFFUhyL4cuCJSaHDA0YNYMELDXX0h8JKtWYxO5XD3Dn+maXOMrVAAiNGooUyM2v/wz/TOaM0jxYVKeXX7g==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.27"
+
+"@fortawesome/react-fontawesome@^0.1.9":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.9.tgz#c865b9286c707407effcec99958043711367cd02"
+  integrity sha512-49V3WNysLZU5fZ3sqSuys4nGRytsrxJktbv3vuaXkEoxv22C6T7TEG0TW6+nqVjMnkfCQd5xOnmJoZHMF78tOw==
+  dependencies:
+    prop-types "^15.7.2"
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"


### PR DESCRIPTION
Adds Exposure Section and multiple select for `SelectBox` and `TextField` with the `allowMultipleProp`.  Examples of usage in the Exposure section.

```Typescript
<SelectBox
    name="foo"
    label="Foo"
    options={fooOptions}
    allowMultiple
/>

<TextField
    name="foo"
    label="Foo"
    options={fooOptions}
    allowMultiple
/>
```

The multiselect for text entry updates pretty slowly in development mode, but is better in the production build.  I was able to make some improvements, but some of the conditional logic and preventing duplicate SelectBox entries made this more complicated than I expected.  I'll keep looking for ways to improve the implementation.