### PR TITLE
Turn off auto-complete in Chrome

### DIFF
--- a/src/components/forms/AutocompleteField/AutocompleteField.js
+++ b/src/components/forms/AutocompleteField/AutocompleteField.js
@@ -17,7 +17,7 @@ export function FormikAutocompleteTextField({ children, options, ...props }) {
   useEffect(() => {
     const input = myRef.current && myRef.current.getElementsByTagName('input')[0];
     input.autocomplete = 'new-password';
-  });
+  }, [myRef]);
 
   return (
     <Autocomplete

--- a/src/components/forms/AutocompleteField/AutocompleteField.js
+++ b/src/components/forms/AutocompleteField/AutocompleteField.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Autocomplete } from '@material-ui/lab';
 import { Field, useFormikContext } from 'formik';
 import { TextField as MUITextField } from '@material-ui/core';
@@ -8,6 +8,17 @@ export function FormikAutocompleteTextField({ children, options, ...props }) {
   const { onChange, onBlur, value, disabled, name, ...rest } = fieldToTextField(props);
   const { setFieldValue } = useFormikContext();
 
+  // The Autocomplete component appears to override the "autocomplete" attribute, setting it to "off"
+  // no matter how you set the autoComplete property in the component. Chrome, however, ignores
+  // autocomplete: "off" and only really turns off autofill if you set it to autocomplete: "new-password".
+  // This code uses an effect to directly change the autocomplete attribute after the component has
+  // updated.
+  const myRef = React.createRef();
+  useEffect(() => {
+    const input = myRef.current && myRef.current.getElementsByTagName('input')[0];
+    input.autocomplete = 'new-password';
+  });
+
   return (
     <Autocomplete
       disableClearable
@@ -16,14 +27,7 @@ export function FormikAutocompleteTextField({ children, options, ...props }) {
       options={options}
       getOptionLabel={option => (typeof option === 'string' ? option : option.label)}
       renderInput={params => (
-        <MUITextField
-          {...params}
-          {...rest}
-          name={name}
-          autoComplete="off"
-          variant="outlined"
-          fullWidth
-        />
+        <MUITextField {...params} {...rest} ref={myRef} name={name} variant="outlined" fullWidth />
       )}
       onChange={(event, value) => {
         setFieldValue(name, value);

--- a/src/components/forms/DateField/DateField.js
+++ b/src/components/forms/DateField/DateField.js
@@ -14,6 +14,7 @@ function FormikKeyboardDatePicker({ children, onChange, ...props }) {
       {...datePickerProps}
       autoOk
       fullWidth
+      autoComplete="new-password"
       variant="inline"
       inputVariant="outlined"
       format="MM/dd/yyyy"

--- a/src/components/forms/TelField/TelField.js
+++ b/src/components/forms/TelField/TelField.js
@@ -17,7 +17,7 @@ export function FormikTelField({ children, ...props }) {
       disabled={disabled}
     >
       {() => (
-        <MUITextField {...rest} fullWidth variant="outlined" type="tel">
+        <MUITextField {...rest} fullWidth autoComplete="new-password" variant="outlined" type="tel">
           {children}
         </MUITextField>
       )}

--- a/src/components/forms/TextField/TextField.js
+++ b/src/components/forms/TextField/TextField.js
@@ -10,7 +10,7 @@ export function FormikTextField({ children, onChange, ...props }) {
   if (onChange) textFieldProps.onChange = onChange;
 
   return (
-    <MUITextField {...textFieldProps} fullWidth variant="outlined">
+    <MUITextField {...textFieldProps} fullWidth autoComplete="new-password" variant="outlined">
       {children}
     </MUITextField>
   );


### PR DESCRIPTION
Chrome doesn't honor autocomplete: "off"; you must use autocomplete: "new-password".

The `Autocomplete` component hard-codes in `autocomplete: "off"`, so I had to do something a little tricky to force that to "new-password".  Hope I did it right! (It works anyway).